### PR TITLE
Add duration-based fixation visualization with heatmap analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 generated_images_v0
 generated_images_v1
 generated_images_v2
+generated_duration_images_v0
+generated_duration_images_v1
+generated_duration_images_v2
 .venv

--- a/duration_fixations_work/fixation_duration_v0/generate_fixation_duration_v0.py
+++ b/duration_fixations_work/fixation_duration_v0/generate_fixation_duration_v0.py
@@ -1,0 +1,137 @@
+# %% Imports
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+
+# %% Settings
+CSV_PATH    = '../../data/P23_T2(in)_valid_fixations.csv'
+OUT_DIR     = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'generated_duration_images_v0')
+SCREEN_RES  = (1920, 1080)   # width, height in pixels
+DPI         = 150            # figure DPI (used with SCREEN_RES to size the canvas)
+
+# duration-based sizing settings
+MIN_SIZE    = 20             # minimum point size
+MAX_SIZE    = 150            # maximum point size
+PREV_ALPHA  = 0.60           # alpha for previous points
+CURR_ALPHA  = 1.00           # alpha for current point
+
+# %% Load the eye-tracking data
+df = pd.read_csv(CSV_PATH)
+print(f"Loaded {len(df)} rows of eye-tracking data")
+print(df.head(3))  # quick peek
+
+# Basic column checks
+required_cols = {'FPOGX', 'FPOGY'}
+if not required_cols.issubset(df.columns):
+    raise ValueError(f"CSV must contain columns {required_cols}")
+
+# Optional: clip normalized coords to [0,1]
+# (comment out if you prefer raw values)
+df['FPOGX'] = df['FPOGX'].clip(0, 1)
+df['FPOGY'] = df['FPOGY'].clip(0, 1)
+
+# %% Create output directory for images
+os.makedirs(OUT_DIR, exist_ok=True)
+print(f"Images will be saved in: {OUT_DIR}")
+
+# Try to resolve optional metadata column names used in your text block
+time_col = 'TIME(2025/05/28 13:20:00.683)'
+if time_col not in df.columns:
+    # fallback: use the first column that starts with 'TIME(' if present
+    t_candidates = [c for c in df.columns if isinstance(c, str) and c.startswith('TIME(')]
+    time_col = t_candidates[0] if t_candidates else None
+
+fpoid_col = 'FPOGID' if 'FPOGID' in df.columns else None
+fpodur_col = 'FPOGD' if 'FPOGD' in df.columns else None
+
+# Check if duration column exists
+if fpodur_col is None:
+    raise ValueError("Duration column (FPOGD) not found. Duration-based sizing requires fixation duration data.")
+
+# Get duration statistics for scaling
+min_duration = df[fpodur_col].min()
+max_duration = df[fpodur_col].max()
+print(f"Duration range: {min_duration:.3f}s to {max_duration:.3f}s")
+
+# %% Cumulative image function (updated point styling)
+def create_duration_fixation_image(data_up_to_row, current_row, output_path,
+                                   screen_res=SCREEN_RES, dpi=DPI,
+                                   min_size=MIN_SIZE, max_size=MAX_SIZE,
+                                   prev_alpha=PREV_ALPHA, curr_alpha=CURR_ALPHA):
+    """
+    Create an image showing all fixation points up to and including the current row.
+    Point sizes are scaled based on fixation duration.
+
+    Previous points: duration-scaled, semi-transparent orange.
+    Current point: duration-scaled, bright yellow with red border.
+    """
+    fig_w = screen_res[0] / dpi
+    fig_h = screen_res[1] / dpi
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), facecolor='black')
+    ax.set_facecolor('black')
+
+    # normalized screen coordinates
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.invert_yaxis()
+    ax.axis('off')
+
+    # Calculate duration-based sizes for all points
+    durations = data_up_to_row[fpodur_col].values
+    # Normalize durations to size range
+    normalized_durations = (durations - min_duration) / (max_duration - min_duration)
+    sizes = min_size + normalized_durations * (max_size - min_size)
+
+    # Plot previous points (all but current) with duration-based sizing
+    if len(data_up_to_row) > 1:
+        prev = data_up_to_row.iloc[:-1]
+        prev_sizes = sizes[:-1]
+        ax.scatter(prev['FPOGX'], prev['FPOGY'],
+                   s=prev_sizes, c='orange', alpha=prev_alpha,
+                   edgecolors='white', linewidths=1.0, zorder=2)
+
+    # Plot the current fixation point with duration-based sizing
+    current_size = sizes[-1]
+    ax.scatter([current_row['FPOGX']], [current_row['FPOGY']],
+               s=current_size, c='yellow', alpha=curr_alpha,
+               edgecolors='red', linewidths=2, zorder=3)
+
+    # Metadata text (shown if columns exist)
+    info_lines = []
+    if time_col is not None and time_col in current_row:
+        info_lines.append(f"Time: {current_row[time_col]}s")
+    if fpoid_col is not None:
+        info_lines.append(f"Fixation ID: {current_row[fpoid_col]}")
+    if fpodur_col is not None:
+        info_lines.append(f"Duration: {current_row[fpodur_col]}s")
+    info_lines.append(f"Points shown: {len(data_up_to_row)}")
+
+    ax.text(0.02, 0.02, "\n".join(info_lines),
+            color='white', fontsize=10, transform=ax.transAxes, va='bottom')
+
+    plt.savefig(output_path, bbox_inches='tight', pad_inches=0, dpi=dpi)
+    plt.close(fig)
+
+# %% Generate images (you can change range to a subset if testing)
+N = len(df)
+for i in range(N):
+    current_row = df.iloc[i]
+    data_up_to_row = df.iloc[:i+1]
+
+    # Use CNT to name files if available; otherwise use index
+    if 'CNT' in df.columns:
+        name_id = int(current_row['CNT'])
+        fname = f"fixation_duration_{name_id:05d}.png"
+    else:
+        fname = f"fixation_duration_{i+1:05d}.png"
+
+    out_path = os.path.join(OUT_DIR, fname)
+    create_duration_fixation_image(data_up_to_row, current_row, out_path)
+
+    if (i + 1) % 500 == 0 or (i + 1) == N:
+        print(f"Created image {i+1}/{N}: {out_path}")
+
+print("Done generating duration-based fixation images.")
+
+# %%

--- a/duration_fixations_work/fixation_duration_v1/generate_fixation_duration_v1.py
+++ b/duration_fixations_work/fixation_duration_v1/generate_fixation_duration_v1.py
@@ -1,0 +1,168 @@
+# %% Imports
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.ndimage import gaussian_filter
+
+# %% Settings
+CSV_PATH    = '../../data/P23_T2(in)_valid_fixations.csv'
+OUT_DIR     = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'generated_duration_images_v1')
+SCREEN_RES  = (1920, 1080)   # width, height in pixels
+DPI         = 150            # figure DPI (used with SCREEN_RES to size the canvas)
+
+# heat map settings
+GRID_SIZE   = (192, 108)     # heat map grid resolution (1/10th of screen res for performance)
+BLUR_SIGMA  = 2.0           # gaussian blur radius for heat map smoothing
+MIN_ALPHA   = 0.3           # minimum alpha for heat map overlay
+MAX_ALPHA   = 0.8           # maximum alpha for heat map overlay
+
+# current point settings
+CURR_SIZE   = 100           # size for current point marker
+CURR_ALPHA  = 1.0           # alpha for current point
+
+# %% Load the eye-tracking data
+df = pd.read_csv(CSV_PATH)
+print(f"Loaded {len(df)} rows of eye-tracking data")
+
+# Basic column checks
+required_cols = {'FPOGX', 'FPOGY'}
+if not required_cols.issubset(df.columns):
+    raise ValueError(f"CSV must contain columns {required_cols}")
+
+# Optional: clip normalized coords to [0,1]
+df['FPOGX'] = df['FPOGX'].clip(0, 1)
+df['FPOGY'] = df['FPOGY'].clip(0, 1)
+
+# %% Create output directory for images
+os.makedirs(OUT_DIR, exist_ok=True)
+print(f"Images will be saved in: {OUT_DIR}")
+
+# Try to resolve optional metadata column names
+time_col = 'TIME(2025/05/28 13:20:00.683)'
+if time_col not in df.columns:
+    t_candidates = [c for c in df.columns if isinstance(c, str) and c.startswith('TIME(')]
+    time_col = t_candidates[0] if t_candidates else None
+
+fpoid_col = 'FPOGID' if 'FPOGID' in df.columns else None
+fpodur_col = 'FPOGD' if 'FPOGD' in df.columns else None
+
+# Check if duration column exists
+if fpodur_col is None:
+    raise ValueError("Duration column (FPOGD) not found. Duration-based heat mapping requires fixation duration data.")
+
+# Get duration statistics for scaling
+min_duration = df[fpodur_col].min()
+max_duration = df[fpodur_col].max()
+print(f"Duration range: {min_duration:.3f}s to {max_duration:.3f}s")
+
+# %% Heat map generation function
+def create_duration_heatmap_image(data_up_to_row, current_row, output_path,
+                                  screen_res=SCREEN_RES, dpi=DPI, grid_size=GRID_SIZE,
+                                  blur_sigma=BLUR_SIGMA, min_alpha=MIN_ALPHA, max_alpha=MAX_ALPHA,
+                                  curr_size=CURR_SIZE, curr_alpha=CURR_ALPHA):
+    """
+    Create an image with a duration-based heat map of all fixations up to current row.
+    Each fixation creates a heat blob proportional to its duration.
+    Current point is highlighted with a bright marker.
+    """
+    fig_w = screen_res[0] / dpi
+    fig_h = screen_res[1] / dpi
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), facecolor='black')
+    ax.set_facecolor('black')
+
+    # normalized screen coordinates
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.invert_yaxis()
+    ax.axis('off')
+
+    # Create heat map grid (height, width for array indexing)
+    heat_grid = np.zeros((grid_size[1], grid_size[0]))
+
+    # Convert fixation positions to grid coordinates
+    x_positions = data_up_to_row['FPOGX'].values
+    y_positions = data_up_to_row['FPOGY'].values
+    durations = data_up_to_row[fpodur_col].values
+
+    # Normalize durations to [0, 1] for heat intensity
+    normalized_durations = (durations - min_duration) / (max_duration - min_duration)
+
+    # Add each fixation to the heat map
+    for x, y, intensity in zip(x_positions, y_positions, normalized_durations):
+        # Convert normalized coords to grid indices
+        # Note: grid_size is (width, height) but array indexing is [height, width]
+        grid_x = int(x * (grid_size[0] - 1))
+        grid_y = int(y * (grid_size[1] - 1))
+
+        # Ensure indices are within bounds
+        grid_x = max(0, min(grid_size[0] - 1, grid_x))
+        grid_y = max(0, min(grid_size[1] - 1, grid_y))
+
+        # Add intensity to the heat map (accumulative for overlapping fixations)
+        # Array indexing: heat_grid[row, col] = heat_grid[y, x]
+        heat_grid[grid_y, grid_x] += intensity
+
+    # Apply gaussian blur for smooth heat map
+    if blur_sigma > 0:
+        heat_grid = gaussian_filter(heat_grid, sigma=blur_sigma)
+
+    # Normalize heat map to [0, 1]
+    if heat_grid.max() > 0:
+        heat_grid = heat_grid / heat_grid.max()
+
+    # Create heat map overlay with varying alpha
+    if heat_grid.max() > 0:
+        # Create RGBA heat map (red-yellow-white colormap)
+        heat_rgba = plt.cm.hot(heat_grid)
+
+        # Set alpha based on heat intensity
+        alpha_map = min_alpha + heat_grid * (max_alpha - min_alpha)
+        heat_rgba[..., 3] = alpha_map
+
+        # Display heat map
+        ax.imshow(heat_rgba, extent=[0, 1, 1, 0], aspect='auto', interpolation='bilinear')
+
+    # Plot the current fixation point with bright marker
+    ax.scatter([current_row['FPOGX']], [current_row['FPOGY']],
+               s=curr_size, c='cyan', alpha=curr_alpha,
+               edgecolors='white', linewidths=2, zorder=10)
+
+    # Metadata text
+    info_lines = []
+    if time_col is not None and time_col in current_row:
+        info_lines.append(f"Time: {current_row[time_col]}s")
+    if fpoid_col is not None:
+        info_lines.append(f"Fixation ID: {current_row[fpoid_col]}")
+    if fpodur_col is not None:
+        info_lines.append(f"Duration: {current_row[fpodur_col]}s")
+    info_lines.append(f"Points shown: {len(data_up_to_row)}")
+
+    ax.text(0.02, 0.02, "\n".join(info_lines),
+            color='white', fontsize=10, transform=ax.transAxes, va='bottom')
+
+    plt.savefig(output_path, bbox_inches='tight', pad_inches=0, dpi=dpi)
+    plt.close(fig)
+
+# %% Generate images
+N = len(df)
+for i in range(N):
+    current_row = df.iloc[i]
+    data_up_to_row = df.iloc[:i+1]
+
+    # Use CNT to name files if available; otherwise use index
+    if 'CNT' in df.columns:
+        name_id = int(current_row['CNT'])
+        fname = f"fixation_heatmap_{name_id:05d}.png"
+    else:
+        fname = f"fixation_heatmap_{i+1:05d}.png"
+
+    out_path = os.path.join(OUT_DIR, fname)
+    create_duration_heatmap_image(data_up_to_row, current_row, out_path)
+
+    if (i + 1) % 500 == 0 or (i + 1) == N:
+        print(f"Created heat map image {i+1}/{N}: {out_path}")
+
+print("Done generating duration-based heat map images.")
+
+# %%

--- a/duration_fixations_work/fixation_duration_v2/generate_fixation_duration_v2.py
+++ b/duration_fixations_work/fixation_duration_v2/generate_fixation_duration_v2.py
@@ -1,0 +1,187 @@
+# %% Imports
+import os
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.ndimage import gaussian_filter
+
+# %% Settings
+CSV_PATH    = '../../data/P23_T2(in)_valid_fixations.csv'
+OUT_DIR     = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'generated_duration_images_v2')
+SCREEN_RES  = (1920, 1080)   # width, height in pixels
+DPI         = 150            # figure DPI (used with SCREEN_RES to size the canvas)
+
+# heat map settings - increased visibility to persist over many points
+GRID_SIZE   = (192, 108)     # heat map grid resolution (1/10th of screen res for performance)
+BLUR_SIGMA  = 2.0           # gaussian blur radius for heat map smoothing
+MIN_ALPHA   = 0.4           # minimum alpha for heat map overlay (increased to stay visible)
+MAX_ALPHA   = 0.7           # maximum alpha for heat map overlay (increased to stay visible)
+
+# duration-based point sizing settings (from v0)
+MIN_SIZE    = 20             # minimum point size
+MAX_SIZE    = 150            # maximum point size
+PREV_ALPHA  = 0.70           # alpha for previous points
+CURR_ALPHA  = 1.00           # alpha for current point
+
+# %% Load the eye-tracking data
+df = pd.read_csv(CSV_PATH)
+print(f"Loaded {len(df)} rows of eye-tracking data")
+
+# Basic column checks
+required_cols = {'FPOGX', 'FPOGY'}
+if not required_cols.issubset(df.columns):
+    raise ValueError(f"CSV must contain columns {required_cols}")
+
+# Optional: clip normalized coords to [0,1]
+df['FPOGX'] = df['FPOGX'].clip(0, 1)
+df['FPOGY'] = df['FPOGY'].clip(0, 1)
+
+# %% Create output directory for images
+os.makedirs(OUT_DIR, exist_ok=True)
+print(f"Images will be saved in: {OUT_DIR}")
+
+# Try to resolve optional metadata column names
+time_col = 'TIME(2025/05/28 13:20:00.683)'
+if time_col not in df.columns:
+    t_candidates = [c for c in df.columns if isinstance(c, str) and c.startswith('TIME(')]
+    time_col = t_candidates[0] if t_candidates else None
+
+fpoid_col = 'FPOGID' if 'FPOGID' in df.columns else None
+fpodur_col = 'FPOGD' if 'FPOGD' in df.columns else None
+
+# Check if duration column exists
+if fpodur_col is None:
+    raise ValueError("Duration column (FPOGD) not found. Duration-based visualization requires fixation duration data.")
+
+# Get duration statistics for scaling
+min_duration = df[fpodur_col].min()
+max_duration = df[fpodur_col].max()
+print(f"Duration range: {min_duration:.3f}s to {max_duration:.3f}s")
+
+# %% Combined heatmap + persistent points function
+def create_combined_duration_image(data_up_to_row, current_row, output_path,
+                                  screen_res=SCREEN_RES, dpi=DPI, grid_size=GRID_SIZE,
+                                  blur_sigma=BLUR_SIGMA, min_alpha=MIN_ALPHA, max_alpha=MAX_ALPHA,
+                                  min_size=MIN_SIZE, max_size=MAX_SIZE,
+                                  prev_alpha=PREV_ALPHA, curr_alpha=CURR_ALPHA):
+    """
+    Create an image combining:
+    1. Duration-based heatmap (background with reduced alpha from v1)
+    2. Persistent duration-scaled points (from v0)
+
+    This keeps the heat context while preserving individual fixation visibility.
+    """
+    fig_w = screen_res[0] / dpi
+    fig_h = screen_res[1] / dpi
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h), facecolor='black')
+    ax.set_facecolor('black')
+
+    # normalized screen coordinates
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.invert_yaxis()
+    ax.axis('off')
+
+    # === HEATMAP LAYER (background) ===
+    # Create heat map grid (height, width for array indexing)
+    heat_grid = np.zeros((grid_size[1], grid_size[0]))
+
+    # Convert fixation positions to grid coordinates
+    x_positions = data_up_to_row['FPOGX'].values
+    y_positions = data_up_to_row['FPOGY'].values
+    durations = data_up_to_row[fpodur_col].values
+
+    # Normalize durations to [0, 1] for heat intensity
+    normalized_durations = (durations - min_duration) / (max_duration - min_duration)
+
+    # Add each fixation to the heat map
+    for x, y, intensity in zip(x_positions, y_positions, normalized_durations):
+        # Convert normalized coords to grid indices
+        grid_x = int(x * (grid_size[0] - 1))
+        grid_y = int(y * (grid_size[1] - 1))
+
+        # Ensure indices are within bounds
+        grid_x = max(0, min(grid_size[0] - 1, grid_x))
+        grid_y = max(0, min(grid_size[1] - 1, grid_y))
+
+        # Add intensity to the heat map (accumulative for overlapping fixations)
+        heat_grid[grid_y, grid_x] += intensity
+
+    # Apply gaussian blur for smooth heat map
+    if blur_sigma > 0:
+        heat_grid = gaussian_filter(heat_grid, sigma=blur_sigma)
+
+    # Normalize heat map to [0, 1]
+    if heat_grid.max() > 0:
+        heat_grid = heat_grid / heat_grid.max()
+
+    # Create heat map overlay with reduced alpha (background effect)
+    if heat_grid.max() > 0:
+        # Create RGBA heat map (red-yellow-white colormap)
+        heat_rgba = plt.cm.hot(heat_grid)
+
+        # Set alpha based on heat intensity (reduced for background effect)
+        alpha_map = min_alpha + heat_grid * (max_alpha - min_alpha)
+        heat_rgba[..., 3] = alpha_map
+
+    # === PERSISTENT POINTS LAYER (background) ===
+    # Calculate duration-based sizes for all points
+    sizes = min_size + normalized_durations * (max_size - min_size)
+
+    # Plot previous points (all but current) with duration-based sizing
+    if len(data_up_to_row) > 1:
+        prev = data_up_to_row.iloc[:-1]
+        prev_sizes = sizes[:-1]
+        ax.scatter(prev['FPOGX'], prev['FPOGY'],
+                   s=prev_sizes, c='orange', alpha=prev_alpha,
+                   edgecolors='white', linewidths=1.0, zorder=2)
+
+    # Plot the current fixation point with duration-based sizing
+    current_size = sizes[-1]
+    ax.scatter([current_row['FPOGX']], [current_row['FPOGY']],
+               s=current_size, c='cyan', alpha=curr_alpha,
+               edgecolors='white', linewidths=2, zorder=3)
+
+    # === HEATMAP OVERLAY (top layer) ===
+    # Display heat map as top layer (overlaying points) only if there's heat data
+    if heat_grid.max() > 0:
+        ax.imshow(heat_rgba, extent=[0, 1, 1, 0], aspect='auto', interpolation='bilinear', zorder=10)
+
+    # Metadata text
+    info_lines = []
+    if time_col is not None and time_col in current_row:
+        info_lines.append(f"Time: {current_row[time_col]}s")
+    if fpoid_col is not None:
+        info_lines.append(f"Fixation ID: {current_row[fpoid_col]}")
+    if fpodur_col is not None:
+        info_lines.append(f"Duration: {current_row[fpodur_col]}s")
+    info_lines.append(f"Points shown: {len(data_up_to_row)}")
+
+    ax.text(0.02, 0.02, "\n".join(info_lines),
+            color='white', fontsize=10, transform=ax.transAxes, va='bottom')
+
+    plt.savefig(output_path, bbox_inches='tight', pad_inches=0, dpi=dpi)
+    plt.close(fig)
+
+# %% Generate images
+N = len(df)
+for i in range(N):
+    current_row = df.iloc[i]
+    data_up_to_row = df.iloc[:i+1]
+
+    # Use CNT to name files if available; otherwise use index
+    if 'CNT' in df.columns:
+        name_id = int(current_row['CNT'])
+        fname = f"fixation_combined_{name_id:05d}.png"
+    else:
+        fname = f"fixation_combined_{i+1:05d}.png"
+
+    out_path = os.path.join(OUT_DIR, fname)
+    create_combined_duration_image(data_up_to_row, current_row, out_path)
+
+    if (i + 1) % 500 == 0 or (i + 1) == N:
+        print(f"Created combined image {i+1}/{N}: {out_path}")
+
+print("Done generating combined duration heatmap + persistent points images.")
+
+# %%


### PR DESCRIPTION
Implement Duration and Heatmap:

`generate_fixation_duration_v0.py` = 23m 40.7s

- Looks interesting enough, I think it might have more value than original iteration
- Scales fixations point size by duration and provides better emphasis on outer fixation points.

`generate_fixation_duration_v1.py` = 37m 21.9s

- Since I already had duration points fixation_duration_v0, I tried using them as heatmap points so that longer fixations would create “hotter” spots on the grid. 
- The issue was that the heatmap applied too much smoothing because there are so many datapoints, deviations from the original fixation location quickly lost their trace. It did help produce a better and more ideal heatmap design that I think makes sense to me.

`generate_fixation_duration_v2.py` = 49m 22.3s

- Combined fixation_duration_v0 + fixation_duration_v1 into layered output.
- Overall visuals are promising, especially mid-to-late frames. Initial frames may be less CNN-friendly, but results improve over time.
- Key concern: GRID_SIZE parameter. This directly impacts both performance and resolution of the heatmap.

**Information on GRID_SIZE Parameter (Resolution vs. Performance Trade-off)**
Defines computational grid for fixation-to-cell mapping, duration intensity accumulation, and Gaussian blur.
Options tested / expected:

- 192 × 108 (1/10 resolution):  ~30-49 min. - This is what I did
- 768 × 432 (1/2.5 resolution): ~1–2 hrs
- 1920 × 1080 (Full resolution): ~3–6 hrs pixel-perfect, but heavy compute.
- Note: According to Claude AI

Note: I haven’t tried any other optimizations yet. There could be ways to achieve full resolution heatmaps while keeping them optimized, but I didn’t have time to explore this further.
